### PR TITLE
AssetManager plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,11 @@
         },
         {
             "files": ["*.svelte", ".eslintrc.*"],
-            "rules": { "header/header": "off" }
+            "rules": {
+                "header/header": "off",
+                "no-self-assign": "off",
+                "no-undef": "off"
+            }
         }
     ],
     "plugins": ["svelte", "@typescript-eslint", "header"],

--- a/src/api/objects.ts
+++ b/src/api/objects.ts
@@ -83,7 +83,7 @@ interface AssetInfo {
         url: string;
         loaded: boolean;
         loading: boolean;
-        baseTexture?: BaseTexture;
+        baseTexture: BaseTexture | null;
         textures: Record<string, unknown>;
     }>;
     format: "simple" | "connected";

--- a/src/components/QuartetConfigMenu.svelte
+++ b/src/components/QuartetConfigMenu.svelte
@@ -128,7 +128,7 @@
         margin-right: 10px;
     }
     .qt-author > img {
-        border-radius: 100%;
+        border-radius: 3px;
     }
 
     .control_group .flex-item {

--- a/src/plugins/assetManager/components/SkinSetting.svelte
+++ b/src/plugins/assetManager/components/SkinSetting.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+    import { MinoAssets } from "@api/objects";
+
+    import { get, set, update } from "idb-keyval";
+    import { Skin, skins } from "../index";
+
+    export let value: number | null = null;
+
+    const originalAssets = MinoAssets.tetrio;
+
+    let files: FileList | undefined;
+    let filePicker: HTMLInputElement;
+
+    get("QuartetSkins").then((v: Skin[] = []) => {
+        $skins = v.map(skin => ({ ...skin, url: URL.createObjectURL(skin.file) }));
+    });
+
+    function pushFiles(...files: File[]) {
+        update("QuartetSkins", (old = []) => {
+            $skins = [
+                ...old,
+                ...files.map( file => ({
+                    name: file.name, file, url: URL.createObjectURL(file)
+                }))
+            ];
+            return $skins;
+        });
+    }
+
+    function updateSkin(index: number | null) {
+        if (MinoAssets.tetrio.assets.hd.loaded) {
+            Object.values(MinoAssets.tetrio.assets).map(asset => {
+                asset.baseTexture?.destroy();
+                asset.baseTexture = null;
+                asset.textures = {};
+                asset.loaded = asset.loading = false;
+            });
+        }
+
+        if (index === null || !$skins[index]) {
+            MinoAssets.tetrio = originalAssets;
+            return;
+        }
+
+        const { name, url } = $skins[index];
+        MinoAssets.tetrio = {
+            id: "quartet",
+            name,
+            assets: {
+                hd: {
+                    loaded: false,
+                    loading: false,
+                    textures: {},
+                    url,
+                    baseTexture: null,
+                },
+                uhd: MinoAssets.tetrio.assets.uhd,
+            },
+            colors: MinoAssets.tetrio.colors,
+            format: "simple",
+        };
+    }
+
+    $: pushFiles(...files ?? []);
+    $: set("QuartetSkins", $skins);
+    $: updateSkin(value);
+</script>
+
+<input
+    type="file"
+    accept="image/*"
+    multiple
+    bind:this={filePicker}
+    bind:files
+    id="quartet_skins"
+    name="quartet_skins"
+/>
+
+<div
+    class="control_button rg_target_pri"
+    on:click={() => filePicker.click()}
+    data-hover="tap"
+    data-hit="click"
+>
+    add skins
+</div>
+
+{#each $skins as { file, url }, i}
+    <div class="scroller_block zero">
+        <h3>{i} ({file.size}b)</h3>
+        <div class="button_tr_h">
+            <div
+                class="control_button button_tr_i rg_target_pri danger"
+                on:click={() => {
+                    URL.revokeObjectURL(url);
+                    $skins.splice(i);
+                    $skins = $skins;
+                }}
+            >
+                delete
+            </div>
+        </div>
+
+        <div
+            class="checkbox rg_target_pri"
+            class:checked={value === i}
+            on:click={() => { value = value === i ? null : i }}
+            data-hover="tap"
+            data-hit="click"
+        >
+            use this skin
+        </div>
+
+        <input
+            placeholder="the skin's name"
+            autocomplete="off"
+            class="config_input rg_target_pri"
+            bind:value={$skins[i].name}
+        />
+
+        <img src={url} alt="" />
+    </div>
+{/each}
+
+<style>
+    input[type="file"] {
+        display: none;
+    }
+</style>

--- a/src/plugins/assetManager/index.ts
+++ b/src/plugins/assetManager/index.ts
@@ -16,11 +16,32 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export * as Api from "@api";
-export * as Internal from "@api/internal";
-export * as Objects from "@api/objects";
-export * as Patcher from "patcher";
+import { Devs } from "@api/constants";
+import { definePluginSettings, SettingType } from "@api/settings";
+import { Plugin } from "patcher";
+import { writable } from "svelte/store";
 
-export { Settings } from "@api/settings";
+import SkinSetting from "./components/SkinSetting.svelte";
 
-export * as IDBKeyVal from "idb-keyval";
+const settings = definePluginSettings({
+    skin: {
+        type: SettingType.CUSTOM,
+        component: SkinSetting,
+    },
+});
+
+export interface Skin {
+    name: string;
+    file: File;
+    url: string;
+}
+
+export const skins = writable([] as Skin[]);
+
+export default {
+    name: "AssetManager",
+    description: "meow",
+    authors: [Devs.dzshn],
+    default: true,
+    settings,
+} satisfies Plugin;


### PR DESCRIPTION
The basic idea: load skins from input files, store them in IndexedDB, give blob urls to `MinoAssets`/`GhostAssets` (and maybe more stuff in the future)

The initial commit is a proof of concept of the above.. but not really sane

<details>
<summary>
(the proof of concept in question)
</summary>

![image](https://user-images.githubusercontent.com/54632522/224542317-59b7a4e8-3b4c-4689-af12-073a1463e23b.png)

![image](https://user-images.githubusercontent.com/54632522/224542382-cd5bb916-a4e9-41fd-bbf3-2509d1ee59e9.png)

</details>

Anyhow, we need a format for skins. A zip archive with a json manifest including all the images could do. Being able to pack stuff like CSS with skins would also be useful.

# TODOs

- [ ] Skin format specification
  - [ ] Handle UHD skins
  - [ ] Also connected skins
  - [ ] And `colors`
  - [ ] literally everything
- [ ] Maybe register a `Loader`
- [ ] Actual UX that isnt comically broken
- [ ] Sanely index the skins instead of just keeping them in a list and hope things don't go out of order
- [ ] More TODOs